### PR TITLE
Add EMI fields and employment type

### DIFF
--- a/frontend-2/src/app/client/user-application/employment-details/index.tsx
+++ b/frontend-2/src/app/client/user-application/employment-details/index.tsx
@@ -69,6 +69,49 @@ const EmploymentDetails: FunctionComponent<EmploymentDetailsProps> = ({
         </div>
 
         <div>
+          <label htmlFor="employmentType" className="mb-4 block font-medium">
+            Employment Type*
+          </label>
+          <div className="flex justify-start gap-x-20">
+            <label htmlFor="employmentTypeSalaried" className="font-medium">
+              <input
+                type="radio"
+                id="employmentTypeSalaried"
+                name="employmentType"
+                value="salaried"
+                checked={values.employmentType === "salaried"}
+                onChange={(e) => {
+                  handleChange(e);
+                  handleBlur(e);
+                }}
+                className="mr-4 cursor-pointer rounded border border-[#cadcfc] p-2 uppercase"
+              />
+              Salaried
+            </label>
+
+            <label htmlFor="employmentTypeSelfEmployed" className="font-medium">
+              {" "}
+              <input
+                type="radio"
+                id="employmentTypeSelfEmployed"
+                name="employmentType"
+                value="self-employed"
+                checked={values.employmentType === "self-employed"}
+                onChange={(e) => {
+                  handleChange(e);
+                  handleBlur(e);
+                }}
+                className="mr-4 cursor-pointer rounded border border-[#cadcfc] p-2 uppercase"
+              />
+              Self Employed
+            </label>
+          </div>
+          {errors.employmentType && (
+            <div className="text-red-400">{errors.employmentType}</div>
+          )}
+        </div>
+
+        <div>
           <label htmlFor="monthlyIncome" className="block font-medium">
             Monthly Income*
           </label>
@@ -164,6 +207,24 @@ const EmploymentDetails: FunctionComponent<EmploymentDetailsProps> = ({
           />
           {errors.officialEmail && (
             <div className="text-red-400">{errors.officialEmail}</div>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="otherMonthlyEmi" className="block font-medium">
+            Any Other Monthly EMI
+          </label>
+          <input
+            type="number"
+            id="otherMonthlyEmi"
+            name="otherMonthlyEmi"
+            value={values.otherMonthlyEmi}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            className="h-[48px] w-full rounded border border-[#cadcfc] p-2"
+          />
+          {errors.otherMonthlyEmi && (
+            <div className="text-red-400">{errors.otherMonthlyEmi}</div>
           )}
         </div>
         <div>

--- a/frontend-2/src/app/client/user-application/helpers/handle-submit.ts
+++ b/frontend-2/src/app/client/user-application/helpers/handle-submit.ts
@@ -19,6 +19,8 @@ export const handleSubmit = async (
     "experience",
     "companyaddress",
     "officialEmail",
+    "monthlyRent",
+    "otherMonthlyEmi",
   ];
 
   Object.keys(values).forEach((key) => {
@@ -51,6 +53,8 @@ export const handleSubmit = async (
   formData.append("AadharNo", values.aadhar);
   formData.append("PAN", values.pan);
   formData.append("MonthlyIncome", values.monthlyIncome);
+  formData.append("EmploymentType", values.employmentType);
+  formData.append("OtherMonthlyEmi", values.otherMonthlyEmi);
   formData.append("WorkExperience", values.experience);
   formData.append("EmploymentNature", values.employmentNature);
   formData.append("CompanyName", values.companyname);
@@ -83,6 +87,7 @@ export const handleSubmit = async (
       State: values.state,
       Zip: values.pincode,
       AddressType: values.addressType,
+      MonthlyRent: values.monthlyRent,
     };
 
     //Address Details

--- a/frontend-2/src/app/client/user-application/helpers/validate-field.ts
+++ b/frontend-2/src/app/client/user-application/helpers/validate-field.ts
@@ -112,6 +112,12 @@ export const validateField = (
       }
       break;
 
+    case "monthlyRent":
+      if (value && !NUMBER_REGEX.exec(value)) {
+        error = "Please enter valid amount";
+      }
+      break;
+
     case "addressType":
       if (!value) {
         error = "Please select address type";
@@ -139,8 +145,18 @@ export const validateField = (
         error = "Please select employment nature";
       }
       break;
+    case "employmentType":
+      if (!value) {
+        error = "Please select employment type";
+      }
+      break;
     case "monthlyIncome":
       if (!NUMBER_REGEX.exec(value)) {
+        error = "Please enter valid amount";
+      }
+      break;
+    case "otherMonthlyEmi":
+      if (value && !NUMBER_REGEX.exec(value)) {
         error = "Please enter valid amount";
       }
       break;

--- a/frontend-2/src/app/client/user-application/resedential-address/index.tsx
+++ b/frontend-2/src/app/client/user-application/resedential-address/index.tsx
@@ -155,10 +155,31 @@ const ResedentialAddress: FunctionComponent<TResedentialAddressProps> = ({
               Rented
             </label>
           </div>
-          {errors.addressType && (
-            <div className="text-red-400">{errors.addressType}</div>
+      {errors.addressType && (
+        <div className="text-red-400">{errors.addressType}</div>
+      )}
+      </div>
+        <div>
+          <label htmlFor="monthlyRent" className="block font-medium">
+            Monthly Rent/Home EMI
+          </label>
+          <input
+            type="number"
+            id="monthlyRent"
+            name="monthlyRent"
+            value={values.monthlyRent}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            className="w-full rounded border border-[#cadcfc] p-2"
+          />
+          {errors.monthlyRent && (
+            <div className="text-red-400">{errors.monthlyRent}</div>
           )}
         </div>
+      </div>
+
+      {/* Row 6 */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div>
           <label htmlFor="addressProof" className="block font-medium">
             Upload Address Proof*

--- a/frontend-2/src/app/client/user-application/types.ts
+++ b/frontend-2/src/app/client/user-application/types.ts
@@ -15,6 +15,7 @@ export interface FormValues {
   state: string;
   pincode: string;
   addressType: string;
+  monthlyRent: string;
   addressProof: File | null;
 
   aadhar: string;
@@ -22,8 +23,10 @@ export interface FormValues {
   aadharFile: File | null;
   panFile: File | null;
 
+  employmentType: string;
   employmentNature: string;
   monthlyIncome: string;
+  otherMonthlyEmi: string;
   incomeProof: File | null;
   companyname: string;
   companyaddress: string;
@@ -54,6 +57,7 @@ export const defaultFormValues = {
   state: "",
   pincode: "",
   addressType: "",
+  monthlyRent: "",
   addressProof: null,
 
   aadhar: "",
@@ -61,9 +65,11 @@ export const defaultFormValues = {
   aadharFile: null,
   panFile: null,
 
+  employmentType: "",
   employmentNature: "",
   companyname: "",
   monthlyIncome: "",
+  otherMonthlyEmi: "",
   incomeProof: null,
   experience: "",
   companyaddress: "",

--- a/los-flask-app/los/api/address_routes.py
+++ b/los-flask-app/los/api/address_routes.py
@@ -24,7 +24,8 @@ def create_address():
         City=data["City"],
         State=data["State"],
         Zip=data["Zip"],
-        AddressType=data["AddressType"]
+        AddressType=data["AddressType"],
+        MonthlyRent=data.get("MonthlyRent")
     )
 
     db.session.add(new_address)
@@ -39,7 +40,8 @@ def create_address():
             "City": new_address.City,
             "State": new_address.State,
             "Zip": new_address.Zip,
-            "AddressType": new_address.AddressType
+            "AddressType": new_address.AddressType,
+            "MonthlyRent": new_address.MonthlyRent
         }
     }), 201
 
@@ -56,7 +58,8 @@ def get_addresses():
             "City": a.City,
             "State": a.State,
             "Zip": a.Zip,
-            "AddressType": a.AddressType
+            "AddressType": a.AddressType,
+            "MonthlyRent": a.MonthlyRent
         }
         for a in addresses
     ])
@@ -76,7 +79,8 @@ def get_address(address_id):
         "City": address.City,
         "State": address.State,
         "Zip": address.Zip,
-        "AddressType": address.AddressType
+        "AddressType": address.AddressType,
+        "MonthlyRent": address.MonthlyRent
     })
 
 
@@ -93,6 +97,7 @@ def update_address(address_id):
     address.State = data.get("State", address.State)
     address.Zip = data.get("Zip", address.Zip)
     address.AddressType = data.get("AddressType", address.AddressType)
+    address.MonthlyRent = data.get("MonthlyRent", address.MonthlyRent)
 
     db.session.commit()
 

--- a/los-flask-app/los/api/user_routes.py
+++ b/los-flask-app/los/api/user_routes.py
@@ -67,6 +67,8 @@ def create_user():
         PhoneVerified=phone_verified,
         EmailVerified=email_verified,
         MonthlyIncome=data.get("MonthlyIncome"),
+        EmploymentType=data.get("EmploymentType"),
+        OtherMonthlyEmi=data.get("OtherMonthlyEmi"),
         MaritalStatus=data.get("MaritalStatus"),
         NoOfDependents=data.get("NoOfDependents"),
         RoleID=data["RoleID"],
@@ -112,8 +114,10 @@ def get_users():
             "PANUploadDoc": u.PANUploadDoc,
             "PhoneVerified": u.PhoneVerified,
             "EmailVerified": u.EmailVerified,
-            "MonthlyIncome": u.MonthlyIncome,
-            "MaritalStatus": u.MaritalStatus,
+        "MonthlyIncome": u.MonthlyIncome,
+        "EmploymentType": u.EmploymentType,
+        "OtherMonthlyEmi": u.OtherMonthlyEmi,
+        "MaritalStatus": u.MaritalStatus,
             "NoOfDependents": u.NoOfDependents,
             "RoleID": u.RoleID,
             "CreatedAt": u.CreatedAt
@@ -144,6 +148,8 @@ def get_user(user_id):
         "PhoneVerified": user.PhoneVerified,
         "EmailVerified": user.EmailVerified,
         "MonthlyIncome": user.MonthlyIncome,
+        "EmploymentType": user.EmploymentType,
+        "OtherMonthlyEmi": user.OtherMonthlyEmi,
         "MaritalStatus": user.MaritalStatus,
         "NoOfDependents": user.NoOfDependents,
         "RoleID": user.RoleID,
@@ -172,6 +178,8 @@ def update_user(user_id):
     user.PhoneVerified = data.get("PhoneVerified", user.PhoneVerified)
     user.EmailVerified = data.get("EmailVerified", user.EmailVerified)
     user.MonthlyIncome = data.get("MonthlyIncome", user.MonthlyIncome)
+    user.EmploymentType = data.get("EmploymentType", user.EmploymentType)
+    user.OtherMonthlyEmi = data.get("OtherMonthlyEmi", user.OtherMonthlyEmi)
     user.MaritalStatus = data.get("MaritalStatus", user.MaritalStatus)
     user.NoOfDependents = data.get("NoOfDependents", user.NoOfDependents)
     user.RoleID = data.get("RoleID", user.RoleID)

--- a/los-flask-app/los/models.py
+++ b/los-flask-app/los/models.py
@@ -29,6 +29,8 @@ class User(db.Model):
     PANUploadDoc = db.Column(db.String(255))
     IncomeProofDoc = db.Column(db.String(255))
     MonthlyIncome = db.Column(db.Numeric(10, 2))
+    EmploymentType = db.Column(db.String(255))
+    OtherMonthlyEmi = db.Column(db.Numeric(10, 2))
     MaritalStatus = db.Column(db.String(25))
     NoOfDependents = db.Column(db.Integer)
     EmploymentNature = db.Column(db.String(255))
@@ -69,6 +71,7 @@ class Address(db.Model):
     State = db.Column(db.String(100))
     Zip = db.Column(db.String(20))
     AddressType = db.Column(db.String(25))
+    MonthlyRent = db.Column(db.Numeric(10, 2))
 
     user = db.relationship("User", back_populates="addresses")
 


### PR DESCRIPTION
## Summary
- collect monthly rent or home EMI on address form
- capture employment type and any additional EMIs on employment details
- store new values in form state and validate them
- transmit new fields in form submission
- extend backend models and API to persist employment type, other EMI and monthly rent

## Testing
- `npm run lint` *(fails: `next` not found)*

------