### PR TITLE
Add district field and rebuild migration workflow

### DIFF
--- a/los
+++ b/los
@@ -1,0 +1,1 @@
+los-flask-app/los

--- a/los-flask-app/los/api/address_routes.py
+++ b/los-flask-app/los/api/address_routes.py
@@ -9,7 +9,15 @@ def create_address():
     data = request.json
 
     # Validate required fields
-    required_fields = ["UserID", "Street", "City", "State", "Zip", "AddressType"]
+    required_fields = [
+        "UserID",
+        "Street",
+        "City",
+        "District",
+        "State",
+        "Zip",
+        "AddressType",
+    ]
     if not all(field in data and data[field] for field in required_fields):
         return jsonify({"message": "Missing required fields"}), 400
 
@@ -22,6 +30,7 @@ def create_address():
         UserID=data["UserID"],
         Street=data["Street"],
         City=data["City"],
+        District=data["District"],
         State=data["State"],
         Zip=data["Zip"],
         AddressType=data["AddressType"],
@@ -38,6 +47,7 @@ def create_address():
             "UserID": new_address.UserID,
             "Street": new_address.Street,
             "City": new_address.City,
+            "District": new_address.District,
             "State": new_address.State,
             "Zip": new_address.Zip,
             "AddressType": new_address.AddressType,
@@ -56,6 +66,7 @@ def get_addresses():
             "UserID": a.UserID,
             "Street": a.Street,
             "City": a.City,
+            "District": a.District,
             "State": a.State,
             "Zip": a.Zip,
             "AddressType": a.AddressType,
@@ -77,6 +88,7 @@ def get_address(address_id):
         "UserID": address.UserID,
         "Street": address.Street,
         "City": address.City,
+        "District": address.District,
         "State": address.State,
         "Zip": address.Zip,
         "AddressType": address.AddressType,
@@ -95,6 +107,7 @@ def update_address(address_id):
     address.Street = data.get("Street", address.Street)
     address.City = data.get("City", address.City)
     address.State = data.get("State", address.State)
+    address.District = data.get("District", address.District)
     address.Zip = data.get("Zip", address.Zip)
     address.AddressType = data.get("AddressType", address.AddressType)
     address.MonthlyHomeRent = data.get("MonthlyHomeRent", address.MonthlyHomeRent)

--- a/los-flask-app/los/api/user_routes.py
+++ b/los-flask-app/los/api/user_routes.py
@@ -126,12 +126,18 @@ def get_users():
                 "PAN": u.PAN,
                 "AadharUploadDoc": u.AadharUploadDoc,
                 "PANUploadDoc": u.PANUploadDoc,
+                "IncomeProofDoc": u.IncomeProofDoc,
                 "PhoneVerified": u.PhoneVerified,
                 "EmailVerified": u.EmailVerified,
                 "MonthlyIncome": u.MonthlyIncome,
                 "ExistingEmis": u.ExistingEmis,
                 "MaritalStatus": u.MaritalStatus,
                 "NoOfDependents": u.NoOfDependents,
+                "EmploymentNature": u.EmploymentNature,
+                "WorkExperience": u.WorkExperience,
+                "CompanyName": u.CompanyName,
+                "CompanyAddress": u.CompanyAddress,
+                "OfficialEmail": u.OfficialEmail,
                 "RoleID": u.RoleID,
                 "CreatedAt": u.CreatedAt,
             }
@@ -160,12 +166,18 @@ def get_user(user_id):
             "PAN": user.PAN,
             "AadharUploadDoc": user.AadharUploadDoc,
             "PANUploadDoc": user.PANUploadDoc,
+            "IncomeProofDoc": user.IncomeProofDoc,
             "PhoneVerified": user.PhoneVerified,
             "EmailVerified": user.EmailVerified,
             "MonthlyIncome": user.MonthlyIncome,
             "ExistingEmis": user.ExistingEmis,
             "MaritalStatus": user.MaritalStatus,
             "NoOfDependents": user.NoOfDependents,
+            "EmploymentNature": user.EmploymentNature,
+            "WorkExperience": user.WorkExperience,
+            "CompanyName": user.CompanyName,
+            "CompanyAddress": user.CompanyAddress,
+            "OfficialEmail": user.OfficialEmail,
             "RoleID": user.RoleID,
             "CreatedAt": user.CreatedAt,
         }
@@ -196,6 +208,11 @@ def update_user(user_id):
     user.ExistingEmis = data.get("ExistingEmis", user.ExistingEmis)
     user.MaritalStatus = data.get("MaritalStatus", user.MaritalStatus)
     user.NoOfDependents = data.get("NoOfDependents", user.NoOfDependents)
+    user.EmploymentNature = data.get("EmploymentNature", user.EmploymentNature)
+    user.WorkExperience = data.get("WorkExperience", user.WorkExperience)
+    user.CompanyName = data.get("CompanyName", user.CompanyName)
+    user.CompanyAddress = data.get("CompanyAddress", user.CompanyAddress)
+    user.OfficialEmail = data.get("OfficialEmail", user.OfficialEmail)
     user.RoleID = data.get("RoleID", user.RoleID)
 
     db.session.commit()

--- a/los-flask-app/los/models.py
+++ b/los-flask-app/los/models.py
@@ -97,6 +97,7 @@ class Address(db.Model):
     )
     Street = db.Column(db.String(255))
     City = db.Column(db.String(100))
+    District = db.Column(db.String(100))
     State = db.Column(db.String(100))
     Zip = db.Column(db.String(20))
     AddressType = db.Column(db.String(25))

--- a/migrations/2025-06-30-add-district.sql
+++ b/migrations/2025-06-30-add-district.sql
@@ -1,0 +1,2 @@
+-- Migration: add District column to addresses
+ALTER TABLE addresses ADD COLUMN District VARCHAR(100);


### PR DESCRIPTION
## Summary
- keep frontend fields in sync by exposing employment details in user routes
- accept and return `District` for address routes
- add the new `District` column in models
- allow dropping and recreating DB tables in `apply_migrations.py`
- provide SQL migration for the new column
- link `los` package so tests can import backend modules

## Testing
- `pip install -q -r los-flask-app/requirements.txt`
- `PYTHONPATH=los-flask-app pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a795c7f24832cad5d7cc0f7efe39b