### PR TITLE
Save user credit score

### DIFF
--- a/frontend-2/src/app/client/user-application/helpers/handle-submit.ts
+++ b/frontend-2/src/app/client/user-application/helpers/handle-submit.ts
@@ -129,9 +129,22 @@ export const handleSubmit = async (
     });
     const cibilData = await cibilResponse.json();
 
-    router.push(
-      `/sanction-result?score=${cibilData.score}&maxLoan=${cibilData.maxLoanAllowed}`,
+    window.localStorage.setItem("cibilScore", String(cibilData.score));
+    window.localStorage.setItem(
+      "maxLoanAllowed",
+      String(cibilData.maxLoanAllowed),
     );
+
+    await fetch(`${BACKEND_URL}/api/credit_scores/`, {
+      method: "POST",
+      mode: "cors",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ UserID: userId, Score: cibilData.score }),
+    });
+
+    router.push("/sanction-result");
   } catch (error) {
     console.error("API Request Error:", error);
   }


### PR DESCRIPTION
## Summary
- store calculated CIBIL score and max loan in `localStorage`
- persist new user's score in backend via `/credit_scores/`
- update redirect to `/sanction-result`

## Testing
- `PYTHONPATH=los-flask-app pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a87844a80832cad6fa540b63d0503