### PR TITLE
Update sanction result page

### DIFF
--- a/frontend-2/src/app/sanction-result/page.tsx
+++ b/frontend-2/src/app/sanction-result/page.tsx
@@ -1,9 +1,16 @@
-export default function SanctionResult({
-  searchParams,
-}: {
-  searchParams: { score?: string; maxLoan?: string };
-}) {
-  const { score = "", maxLoan = "" } = searchParams;
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function SanctionResult() {
+  const [score, setScore] = useState("");
+  const [maxLoan, setMaxLoan] = useState("");
+
+  useEffect(() => {
+    setScore(localStorage.getItem("cibilScore") || "");
+    setMaxLoan(localStorage.getItem("maxLoanAllowed") || "");
+  }, []);
+
   return (
     <div className="m-4 flex flex-col items-center">
       <h1 className="mb-4 text-2xl font-bold">Sanction Result</h1>


### PR DESCRIPTION
## Summary
- convert sanction result page to a client component
- read sanction information from `localStorage`

## Testing
- `npm run format`
- `npm run lint`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685a88474314832cb0bca6fe7d341efc