### PR TITLE
Fix cibil API POST endpoint

### DIFF
--- a/frontend-2/src/app/client/user-application/helpers/handle-submit.ts
+++ b/frontend-2/src/app/client/user-application/helpers/handle-submit.ts
@@ -120,7 +120,9 @@ export const handleSubmit = async (
       residenceType: values.addressType.toUpperCase(),
     };
 
-    const cibilResponse = await fetch(`${BACKEND_URL}/api/cibil`, {
+    // The backend route expects a trailing slash. Without it Flask may issue
+    // a redirect for POST requests, which breaks CORS in some browsers.
+    const cibilResponse = await fetch(`${BACKEND_URL}/api/cibil/`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- fix loan application form error by using /api/cibil/ endpoint with trailing slash

## Testing
- `PYTHONPATH=./los-flask-app pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a8bae6394832cafe2b3e567b075f8