### PR TITLE
Add animated loan wizard and offer page

### DIFF
--- a/frontend-2/package-lock.json
+++ b/frontend-2/package-lock.json
@@ -8,10 +8,14 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.1.1",
         "firebase": "^11.5.0",
+        "framer-motion": "^12.19.1",
         "next": "15.1.7",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-hook-form": "^7.58.1",
+        "zod": "^3.25.67"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -760,6 +764,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.1.1.tgz",
+      "integrity": "sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1481,6 +1497,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.5.tgz",
       "integrity": "sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A==",
       "dev": true
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
@@ -3373,6 +3395,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.19.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.19.1.tgz",
+      "integrity": "sha512-nq9hwWAEKf4gzprbOZzKugLV5OVKF7zrNDY6UOVu+4D3ZgIkg8L9Jy6AMrpBM06fhbKJ6LEG6UY5+t7Eq6wNlg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.19.0",
+        "motion-utils": "^12.19.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4425,6 +4474,21 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.19.0.tgz",
+      "integrity": "sha512-m96uqq8VbwxFLU0mtmlsIVe8NGGSdpBvBSHbnnOJQxniPaabvVdGgxSamhuDwBsRhwX7xPxdICgVJlOpzn/5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.19.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
+      "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5168,6 +5232,22 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.58.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.58.1.tgz",
+      "integrity": "sha512-Lml/KZYEEFfPhUVgE0RdCVpnC4yhW+PndRhbiTtdvSlQTL8IfVR+iQkBjLIvmmc6+GGoVeM11z37ktKFPAb0FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {
@@ -6554,6 +6634,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend-2/package.json
+++ b/frontend-2/package.json
@@ -10,10 +10,14 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.1.1",
     "firebase": "^11.5.0",
+    "framer-motion": "^12.19.1",
     "next": "15.1.7",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-hook-form": "^7.58.1",
+    "zod": "^3.25.67"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend-2/src/app/client/loan-wizard/Step1.tsx
+++ b/frontend-2/src/app/client/loan-wizard/Step1.tsx
@@ -1,0 +1,109 @@
+"use client";
+import { useFormContext } from "react-hook-form";
+import { motion } from "framer-motion";
+
+const Step1 = () => {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext();
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -20 }}
+      className="space-y-4"
+    >
+      <h2 className="text-2xl font-bold">Personal Details</h2>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <label htmlFor="firstName" className="block font-medium">
+            First Name
+          </label>
+          <input
+            id="firstName"
+            {...register("firstName")}
+            className="w-full rounded-3xl border border-gray-300 p-2"
+            type="text"
+          />
+          {errors.firstName && (
+            <p className="text-sm text-red-500">{String(errors.firstName.message)}</p>
+          )}
+        </div>
+        <div>
+          <label htmlFor="lastName" className="block font-medium">
+            Last Name
+          </label>
+          <input
+            id="lastName"
+            {...register("lastName")}
+            className="w-full rounded-3xl border border-gray-300 p-2"
+            type="text"
+          />
+          {errors.lastName && (
+            <p className="text-sm text-red-500">{String(errors.lastName.message)}</p>
+          )}
+        </div>
+        <div>
+          <label htmlFor="age" className="block font-medium">
+            Age
+          </label>
+          <input
+            id="age"
+            type="number"
+            {...register("age", { valueAsNumber: true })}
+            className="w-full rounded-3xl border border-gray-300 p-2"
+          />
+          {errors.age && (
+            <p className="text-sm text-red-500">{String(errors.age.message)}</p>
+          )}
+        </div>
+        <div>
+          <label htmlFor="pan" className="block font-medium">
+            PAN
+          </label>
+          <input
+            id="pan"
+            {...register("pan")}
+            className="w-full rounded-3xl border border-gray-300 p-2 uppercase"
+            type="text"
+          />
+          {errors.pan && (
+            <p className="text-sm text-red-500">{String(errors.pan.message)}</p>
+          )}
+        </div>
+        <div>
+          <label htmlFor="salary" className="block font-medium">
+            Monthly Salary
+          </label>
+          <input
+            id="salary"
+            type="number"
+            {...register("salary", { valueAsNumber: true })}
+            className="w-full rounded-3xl border border-gray-300 p-2"
+          />
+          {errors.salary && (
+            <p className="text-sm text-red-500">{String(errors.salary.message)}</p>
+          )}
+        </div>
+        <div>
+          <label htmlFor="existingEmis" className="block font-medium">
+            Existing EMIs
+          </label>
+          <input
+            id="existingEmis"
+            type="number"
+            {...register("existingEmis", { valueAsNumber: true })}
+            className="w-full rounded-3xl border border-gray-300 p-2"
+          />
+          {errors.existingEmis && (
+            <p className="text-sm text-red-500">{String(errors.existingEmis.message)}</p>
+          )}
+        </div>
+      </div>
+    </motion.div>
+  );
+};
+
+export default Step1;

--- a/frontend-2/src/app/client/loan-wizard/Step2.tsx
+++ b/frontend-2/src/app/client/loan-wizard/Step2.tsx
@@ -1,0 +1,124 @@
+"use client";
+import { useFormContext, Controller } from "react-hook-form";
+import { motion } from "framer-motion";
+
+const Step2 = () => {
+  const {
+    register,
+    control,
+    watch,
+    formState: { errors },
+  } = useFormContext();
+
+  const type = watch("addressType");
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -20 }}
+      className="space-y-4"
+    >
+      <h2 className="text-2xl font-bold">Residential Address</h2>
+      <div className="flex gap-4">
+        <label className="flex items-center gap-2">
+          <input
+            type="radio"
+            value="OWNED"
+            {...register("addressType")}
+            className="rounded"
+          />
+          Owned
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="radio"
+            value="RENTED"
+            {...register("addressType")}
+            className="rounded"
+          />
+          Rented
+        </label>
+      </div>
+      {errors.addressType && (
+        <p className="text-sm text-red-500">{String(errors.addressType.message)}</p>
+      )}
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="md:col-span-2">
+          <label htmlFor="line1" className="block font-medium">
+            Address Line
+          </label>
+          <input
+            id="line1"
+            {...register("line1")}
+            className="w-full rounded-3xl border border-gray-300 p-2"
+            type="text"
+          />
+          {errors.line1 && (
+            <p className="text-sm text-red-500">{String(errors.line1.message)}</p>
+          )}
+        </div>
+        <div>
+          <label htmlFor="city" className="block font-medium">
+            City
+          </label>
+          <input
+            id="city"
+            {...register("city")}
+            className="w-full rounded-3xl border border-gray-300 p-2"
+            type="text"
+          />
+          {errors.city && (
+            <p className="text-sm text-red-500">{String(errors.city.message)}</p>
+          )}
+        </div>
+        <div>
+          <label htmlFor="state" className="block font-medium">
+            State
+          </label>
+          <input
+            id="state"
+            {...register("state")}
+            className="w-full rounded-3xl border border-gray-300 p-2"
+            type="text"
+          />
+          {errors.state && (
+            <p className="text-sm text-red-500">{String(errors.state.message)}</p>
+          )}
+        </div>
+        <div>
+          <label htmlFor="pincode" className="block font-medium">
+            Pincode
+          </label>
+          <input
+            id="pincode"
+            {...register("pincode")}
+            className="w-full rounded-3xl border border-gray-300 p-2"
+            type="text"
+          />
+          {errors.pincode && (
+            <p className="text-sm text-red-500">{String(errors.pincode.message)}</p>
+          )}
+        </div>
+        {type === "RENTED" && (
+          <div>
+            <label htmlFor="monthlyHomeRent" className="block font-medium">
+              Monthly Home Rent
+            </label>
+            <input
+              id="monthlyHomeRent"
+              type="number"
+              {...register("monthlyHomeRent", { valueAsNumber: true })}
+              className="w-full rounded-3xl border border-gray-300 p-2"
+            />
+            {errors.monthlyHomeRent && (
+              <p className="text-sm text-red-500">{String(errors.monthlyHomeRent.message)}</p>
+            )}
+          </div>
+        )}
+      </div>
+    </motion.div>
+  );
+};
+
+export default Step2;

--- a/frontend-2/src/app/client/loan-wizard/Step3.tsx
+++ b/frontend-2/src/app/client/loan-wizard/Step3.tsx
@@ -1,0 +1,61 @@
+"use client";
+import { useFormContext } from "react-hook-form";
+import { motion } from "framer-motion";
+
+const Step3 = () => {
+  const {
+    register,
+    watch,
+    formState: { errors },
+  } = useFormContext();
+
+  const addressType = watch("addressType");
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -20 }}
+      className="space-y-6"
+    >
+      <h2 className="text-2xl font-bold">Extras</h2>
+      <div>
+        <label htmlFor="dependents" className="block font-medium">
+          Dependents
+        </label>
+        <select
+          id="dependents"
+          {...register("dependents", { valueAsNumber: true })}
+          className="w-full rounded-3xl border border-gray-300 p-2"
+        >
+          {[0, 1, 2, 3, 4, 5, 6].map((n) => (
+            <option key={n} value={n}>
+              {n}
+            </option>
+          ))}
+        </select>
+        {errors.dependents && (
+          <p className="text-sm text-red-500">{String(errors.dependents.message)}</p>
+        )}
+      </div>
+      <p className="font-medium">
+        Residence Type: <span className="font-semibold">{addressType}</span>
+      </p>
+      <label className="flex items-center gap-2">
+        <input type="checkbox" {...register("confirm", { required: true })} />
+        I confirm that the above details are correct
+      </label>
+      {errors.confirm && (
+        <p className="text-sm text-red-500">Please confirm before submitting.</p>
+      )}
+      <button
+        type="submit"
+        className="mx-auto block rounded-full bg-blue-600 px-6 py-2 text-white hover:bg-blue-500"
+      >
+        Get My Offer →
+      </button>
+    </motion.div>
+  );
+};
+
+export default Step3;

--- a/frontend-2/src/app/client/loan-wizard/Wizard.tsx
+++ b/frontend-2/src/app/client/loan-wizard/Wizard.tsx
@@ -1,0 +1,129 @@
+"use client";
+import { useState } from "react";
+import { useForm, FormProvider } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { motion, AnimatePresence } from "framer-motion";
+import Step1 from "./Step1";
+import Step2 from "./Step2";
+import Step3 from "./Step3";
+import { BACKEND_URL } from "@/constants/layout";
+import { useRouter } from "next/navigation";
+
+const schema = [
+  z.object({
+    firstName: z.string().min(1, "Required"),
+    lastName: z.string().min(1, "Required"),
+    age: z.number().min(18).max(60),
+    pan: z.string().regex(/^[A-Z]{5}[0-9]{4}[A-Z]$/, "Invalid PAN"),
+    salary: z.number().min(0),
+    existingEmis: z.number().min(0),
+  }),
+  z.object({
+    addressType: z.enum(["OWNED", "RENTED"]),
+    line1: z.string().min(1, "Required"),
+    city: z.string().min(1, "Required"),
+    state: z.string().min(1, "Required"),
+    pincode: z.string().min(1, "Required"),
+    monthlyHomeRent: z.number().optional(),
+  }).refine((data) => data.addressType === "RENTED" ? typeof data.monthlyHomeRent === "number" : true, {
+    message: "Required",
+    path: ["monthlyHomeRent"],
+  }),
+  z.object({
+    dependents: z.number().min(0).max(6),
+    confirm: z.boolean().refine((v) => v === true, { message: "Required" }),
+  }),
+];
+
+const Wizard = () => {
+  const [step, setStep] = useState(0);
+  const methods = useForm({
+    resolver: zodResolver(schema[step]),
+    mode: "onBlur",
+    defaultValues: {
+      firstName: "",
+      lastName: "",
+      age: undefined,
+      pan: "",
+      salary: undefined,
+      existingEmis: undefined,
+      addressType: "OWNED",
+      line1: "",
+      city: "",
+      state: "",
+      pincode: "",
+      monthlyHomeRent: undefined,
+      dependents: 0,
+      confirm: false,
+    },
+  });
+  const router = useRouter();
+
+  const next = async () => {
+    const valid = await methods.trigger();
+    if (!valid) return;
+    setStep((s) => Math.min(s + 1, 2));
+  };
+
+  const prev = () => setStep((s) => Math.max(s - 1, 0));
+
+  const onSubmit = async (data: any) => {
+    const payload = {
+      firstName: data.firstName,
+      lastName: data.lastName,
+      age: data.age,
+      pan: data.pan,
+      salary: data.salary,
+      existingEmis: data.existingEmis,
+      addressType: data.addressType,
+      line1: data.line1,
+      city: data.city,
+      state: data.state,
+      pincode: data.pincode,
+      monthlyHomeRent: data.monthlyHomeRent || 0,
+      dependents: data.dependents,
+      residenceType: data.addressType,
+    };
+    try {
+      const res = await fetch(`${BACKEND_URL}/api/cibil/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json();
+      localStorage.setItem("cibilScore", String(json.score));
+      localStorage.setItem("maxLoanAllowed", String(json.maxLoanAllowed));
+      router.push("/sanction-result");
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const steps = [<Step1 key={0} />, <Step2 key={1} />, <Step3 key={2} />];
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={methods.handleSubmit(onSubmit)} className="mx-auto max-w-xl space-y-6 rounded-3xl bg-white/10 p-6 backdrop-blur">
+        <div className="h-2 w-full overflow-hidden rounded-full bg-gray-200">
+          <div className="h-full bg-blue-500" style={{ width: `${((step + 1) / 3) * 100}%` }} />
+        </div>
+        <AnimatePresence mode="wait">{steps[step]}</AnimatePresence>
+        <div className="flex justify-between">
+          {step > 0 && (
+            <button type="button" onClick={prev} className="rounded-full bg-gray-200 px-4 py-2">
+              Back
+            </button>
+          )}
+          {step < steps.length - 1 && (
+            <button type="button" onClick={next} className="ml-auto rounded-full bg-blue-600 px-4 py-2 text-white">
+              Next
+            </button>
+          )}
+        </div>
+      </form>
+    </FormProvider>
+  );
+};
+
+export default Wizard;

--- a/frontend-2/src/app/client/loan-wizard/index.tsx
+++ b/frontend-2/src/app/client/loan-wizard/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./Wizard";

--- a/frontend-2/src/app/layout.tsx
+++ b/frontend-2/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${inter.variable}`}>
+      <body className={`${inter.variable} bg-gradient-to-br from-[#0F172A] to-[#334155] text-white min-h-screen`}>
         <Header />
         <main className="flex min-h-[85vh] w-full mt-10 justify-center">
           {children}

--- a/frontend-2/src/app/sanction-result/page.tsx
+++ b/frontend-2/src/app/sanction-result/page.tsx
@@ -1,21 +1,75 @@
 "use client";
-
 import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
 
 export default function SanctionResult() {
-  const [score, setScore] = useState("");
-  const [maxLoan, setMaxLoan] = useState("");
+  const [score, setScore] = useState(0);
+  const [maxLoan, setMaxLoan] = useState(0);
+  const [tenure, setTenure] = useState(1);
 
   useEffect(() => {
-    setScore(localStorage.getItem("cibilScore") || "");
-    setMaxLoan(localStorage.getItem("maxLoanAllowed") || "");
+    const s = Number(localStorage.getItem("cibilScore") || 0);
+    const m = Number(localStorage.getItem("maxLoanAllowed") || 0);
+    setScore(s);
+    setMaxLoan(m);
   }, []);
 
+  const emi = Math.round(maxLoan / (tenure * 12));
+
   return (
-    <div className="m-4 flex flex-col items-center">
-      <h1 className="mb-4 text-2xl font-bold">Sanction Result</h1>
-      <p>Your CIBIL Score: {score}</p>
-      <p>Maximum Loan You’re Eligible For: ₹{maxLoan}</p>
-    </div>
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className="mx-auto mt-10 max-w-md space-y-6 rounded-3xl bg-white/10 p-6 text-center backdrop-blur"
+    >
+      <h1 className="text-3xl font-bold">🎉 Your Offer Is Ready!</h1>
+      <div className="flex justify-around">
+        <motion.div whileHover={{ rotateY: 180 }} className="w-1/2 p-4">
+          <div className="rounded-3xl bg-white/20 p-4 shadow">
+            <p className="text-sm">CIBIL Score</p>
+            <p className="text-2xl font-bold">{score}</p>
+          </div>
+        </motion.div>
+        <motion.div whileHover={{ rotateY: 180 }} className="w-1/2 p-4">
+          <div className="rounded-3xl bg-white/20 p-4 shadow">
+            <p className="text-sm">Max Loan ₹</p>
+            <p className="text-2xl font-bold">{maxLoan}</p>
+          </div>
+        </motion.div>
+      </div>
+      <div className="space-y-2">
+        <p className="font-medium">Choose Tenure</p>
+        <div className="flex justify-center gap-2">
+          {[1, 2, 3].map((y) => (
+            <button
+              key={y}
+              onClick={() => setTenure(y)}
+              className={`rounded-full px-4 py-1 ${tenure === y ? "bg-blue-600 text-white" : "bg-gray-200"}`}
+            >
+              {y} {y === 1 ? "Year" : "Years"}
+            </button>
+          ))}
+        </div>
+        <p className="text-lg">EMI preview: ₹{emi} / mo</p>
+      </div>
+      <div className="mt-4 flex justify-center gap-4">
+        <motion.button
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+          onClick={() => alert("Accepted")}
+          className="rounded-full bg-blue-600 px-4 py-2 text-white"
+        >
+          Accept Offer
+        </motion.button>
+        <motion.button
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+          onClick={() => alert("Declined")}
+          className="rounded-full bg-orange-500 px-4 py-2 text-white"
+        >
+          Decline
+        </motion.button>
+      </div>
+    </motion.div>
   );
 }

--- a/frontend-2/src/app/styles/globals.css
+++ b/frontend-2/src/app/styles/globals.css
@@ -18,5 +18,5 @@
     "Helvetica Neue",
     sans-serif;
 
-  color: #00246b
+  color: inherit;
 }

--- a/frontend-2/src/app/user-application/page.tsx
+++ b/frontend-2/src/app/user-application/page.tsx
@@ -1,7 +1,5 @@
-import UserApplication from "../client/user-application";
+import Wizard from "../client/loan-wizard";
 
-
-export default async function UserApplicationPage(){
-
-  return <UserApplication data={{}} />;
+export default function UserApplicationPage() {
+  return <Wizard />;
 }


### PR DESCRIPTION
## Summary
- install framer motion, react-hook-form and zod
- implement new multi-step loan application wizard
- redesign sanction result page with tenure picker and EMI preview
- apply gradient layout background and neutral global text color

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a91db0374832c81278ec6ce6aab0f