### PR TITLE
Fix form fields and CIBIL handling

### DIFF
--- a/frontend-2/src/app/client/loan-wizard/Wizard.tsx
+++ b/frontend-2/src/app/client/loan-wizard/Wizard.tsx
@@ -92,8 +92,12 @@ const Wizard = () => {
         body: JSON.stringify(payload),
       });
       const json = await res.json();
-      localStorage.setItem("cibilScore", String(json.score));
-      localStorage.setItem("maxLoanAllowed", String(json.maxLoanAllowed));
+      if (typeof json.score === "number" && !isNaN(json.score)) {
+        localStorage.setItem("cibilScore", String(json.score));
+      }
+      if (typeof json.maxLoanAllowed === "number" && !isNaN(json.maxLoanAllowed)) {
+        localStorage.setItem("maxLoanAllowed", String(json.maxLoanAllowed));
+      }
       router.push("/sanction-result");
     } catch (e) {
       console.error(e);

--- a/frontend-2/src/app/client/user-application/helpers/handle-submit.ts
+++ b/frontend-2/src/app/client/user-application/helpers/handle-submit.ts
@@ -131,11 +131,18 @@ export const handleSubmit = async (
     });
     const cibilData = await cibilResponse.json();
 
-    window.localStorage.setItem("cibilScore", String(cibilData.score));
-    window.localStorage.setItem(
-      "maxLoanAllowed",
-      String(cibilData.maxLoanAllowed),
-    );
+    if (typeof cibilData.score === "number" && !isNaN(cibilData.score)) {
+      window.localStorage.setItem("cibilScore", String(cibilData.score));
+    }
+    if (
+      typeof cibilData.maxLoanAllowed === "number" &&
+      !isNaN(cibilData.maxLoanAllowed)
+    ) {
+      window.localStorage.setItem(
+        "maxLoanAllowed",
+        String(cibilData.maxLoanAllowed),
+      );
+    }
 
     await fetch(`${BACKEND_URL}/api/credit_scores/`, {
       method: "POST",

--- a/frontend-2/src/app/sanction-result/page.tsx
+++ b/frontend-2/src/app/sanction-result/page.tsx
@@ -8,10 +8,10 @@ export default function SanctionResult() {
   const [tenure, setTenure] = useState(1);
 
   useEffect(() => {
-    const s = Number(localStorage.getItem("cibilScore") || 0);
-    const m = Number(localStorage.getItem("maxLoanAllowed") || 0);
-    setScore(s);
-    setMaxLoan(m);
+    const s = Number(localStorage.getItem("cibilScore"));
+    const m = Number(localStorage.getItem("maxLoanAllowed"));
+    setScore(isNaN(s) ? 0 : s);
+    setMaxLoan(isNaN(m) ? 0 : m);
   }, []);
 
   const emi = Math.round(maxLoan / (tenure * 12));

--- a/frontend-2/src/app/styles/globals.css
+++ b/frontend-2/src/app/styles/globals.css
@@ -20,3 +20,9 @@
 
   color: inherit;
 }
+
+input,
+textarea,
+select {
+  color: #000;
+}

--- a/frontend-2/src/app/user-application/page.tsx
+++ b/frontend-2/src/app/user-application/page.tsx
@@ -1,5 +1,5 @@
-import Wizard from "../client/loan-wizard";
+import UserApplication from "../client/user-application";
 
 export default function UserApplicationPage() {
-  return <Wizard />;
+  return <UserApplication data={{}} />;
 }


### PR DESCRIPTION
## Summary
- make page `/user-application` show full application form again
- ensure input text uses a dark color
- guard CIBIL score saves against `NaN`
- avoid `NaN` when reading stored score values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a9518b93c832c8f0b04672b4bcfe2