### PR TITLE
Add offer calculator with slider and breakdown

### DIFF
--- a/frontend-2/src/app/sanction-result/page.tsx
+++ b/frontend-2/src/app/sanction-result/page.tsx
@@ -1,20 +1,39 @@
 "use client";
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
+import AmountSlider from "@/components/AmountSlider";
+import TenureSelector from "@/components/TenureSelector";
+import CostBreakdownCard from "@/components/CostBreakdownCard";
+import { useLoanCalculator } from "@/hooks/useLoanCalculator";
 
 export default function SanctionResult() {
   const [score, setScore] = useState(0);
-  const [maxLoan, setMaxLoan] = useState(0);
-  const [tenure, setTenure] = useState(1);
+  const [sanctionedMax, setSanctionedMax] = useState(0);
+  const [amount, setAmount] = useState(0);
+  const [tenure, setTenure] = useState<1 | 2 | 3>(1);
 
   useEffect(() => {
     const s = Number(localStorage.getItem("cibilScore"));
     const m = Number(localStorage.getItem("maxLoanAllowed"));
     setScore(isNaN(s) ? 0 : s);
-    setMaxLoan(isNaN(m) ? 0 : m);
+    setSanctionedMax(isNaN(m) ? 0 : m);
+    setAmount(isNaN(m) ? 0 : m);
   }, []);
 
-  const emi = Math.round(maxLoan / (tenure * 12));
+  const breakdown = useLoanCalculator(amount, tenure);
+
+  const acceptOffer = async () => {
+    try {
+      await fetch("/loans", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ amount, tenureYears: tenure }),
+      });
+      alert("Accepted");
+    } catch (e) {
+      console.error(e);
+    }
+  };
 
   return (
     <motion.div
@@ -32,31 +51,19 @@ export default function SanctionResult() {
         </motion.div>
         <motion.div whileHover={{ rotateY: 180 }} className="w-1/2 p-4">
           <div className="rounded-3xl bg-white/20 p-4 shadow">
-            <p className="text-sm">Max Loan ₹</p>
-            <p className="text-2xl font-bold">{maxLoan}</p>
+            <p className="text-sm">Sanctioned Max ₹</p>
+            <p className="text-2xl font-bold">{sanctionedMax}</p>
           </div>
         </motion.div>
       </div>
-      <div className="space-y-2">
-        <p className="font-medium">Choose Tenure</p>
-        <div className="flex justify-center gap-2">
-          {[1, 2, 3].map((y) => (
-            <button
-              key={y}
-              onClick={() => setTenure(y)}
-              className={`rounded-full px-4 py-1 ${tenure === y ? "bg-blue-600 text-white" : "bg-gray-200"}`}
-            >
-              {y} {y === 1 ? "Year" : "Years"}
-            </button>
-          ))}
-        </div>
-        <p className="text-lg">EMI preview: ₹{emi} / mo</p>
-      </div>
+      <AmountSlider value={amount} max={sanctionedMax} onChange={setAmount} />
+      <TenureSelector value={tenure} onChange={setTenure} />
+      <CostBreakdownCard {...breakdown} />
       <div className="mt-4 flex justify-center gap-4">
         <motion.button
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
-          onClick={() => alert("Accepted")}
+          onClick={acceptOffer}
           className="rounded-full bg-blue-600 px-4 py-2 text-white"
         >
           Accept Offer

--- a/frontend-2/src/components/AmountSlider.tsx
+++ b/frontend-2/src/components/AmountSlider.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { useCallback } from "react";
+
+interface AmountSliderProps {
+  value: number;
+  max: number;
+  onChange: (value: number) => void;
+}
+
+const format = (n: number) =>
+  new Intl.NumberFormat("en-IN", { maximumFractionDigits: 0 }).format(n);
+
+export default function AmountSlider({ value, max, onChange }: AmountSliderProps) {
+  const handleChange = useCallback(
+    (val: string) => {
+      const num = Math.min(Math.max(10000, Number(val)), max);
+      onChange(num);
+    },
+    [max, onChange]
+  );
+
+  return (
+    <div className="space-y-2">
+      <p className="font-medium">Select Loan Amount</p>
+      <input
+        type="range"
+        min={10000}
+        max={max}
+        step={1000}
+        value={value}
+        onChange={(e) => handleChange(e.target.value)}
+        className="w-full"
+      />
+      <input
+        type="number"
+        min={10000}
+        max={max}
+        step={1000}
+        value={value}
+        onChange={(e) => handleChange(e.target.value)}
+        className="w-full rounded border px-2 text-black"
+      />
+      <p className="text-sm">₹{format(value)}</p>
+    </div>
+  );
+}

--- a/frontend-2/src/components/CostBreakdownCard.tsx
+++ b/frontend-2/src/components/CostBreakdownCard.tsx
@@ -1,0 +1,58 @@
+"use client";
+import { motion } from "framer-motion";
+
+export interface Breakdown {
+  emi: number;
+  rate: number;
+  processingFee: number;
+  legalFee: number;
+  cashback: number;
+  netDisbursed: number;
+}
+
+const format = (n: number) =>
+  new Intl.NumberFormat("en-IN", { maximumFractionDigits: 0 }).format(n);
+
+export default function CostBreakdownCard({
+  emi,
+  rate,
+  processingFee,
+  legalFee,
+  cashback,
+  netDisbursed,
+}: Breakdown) {
+  return (
+    <motion.div layout className="rounded-3xl bg-white/20 p-4 shadow">
+      <table className="w-full text-left">
+        <tbody>
+          <tr>
+            <td className="py-1">EMI</td>
+            <td className="py-1 text-right">₹{format(Math.round(emi))}</td>
+          </tr>
+          <tr>
+            <td className="py-1">Interest %</td>
+            <td className="py-1 text-right">{rate} % p.a.</td>
+          </tr>
+          <tr>
+            <td className="py-1">Processing</td>
+            <td className="py-1 text-right">₹{format(Math.round(processingFee))}</td>
+          </tr>
+          <tr>
+            <td className="py-1">Legal Fee</td>
+            <td className="py-1 text-right">₹{format(Math.round(legalFee))}</td>
+          </tr>
+          <tr>
+            <td className="py-1">Cashback</td>
+            <td className="py-1 text-right">-₹{format(Math.round(cashback))}</td>
+          </tr>
+          <tr>
+            <td className="py-1 font-semibold">Net Receive</td>
+            <td className="py-1 text-right font-semibold">
+              ₹{format(Math.round(netDisbursed))}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </motion.div>
+  );
+}

--- a/frontend-2/src/components/TenureSelector.tsx
+++ b/frontend-2/src/components/TenureSelector.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+interface TenureSelectorProps {
+  value: 1 | 2 | 3;
+  onChange: (val: 1 | 2 | 3) => void;
+}
+
+export default function TenureSelector({ value, onChange }: TenureSelectorProps) {
+  return (
+    <div className="space-y-2">
+      <p className="font-medium">Select Tenure</p>
+      <div className="flex justify-center gap-2">
+        {[1, 2, 3].map((y) => (
+          <button
+            key={y}
+            type="button"
+            onClick={() => onChange(y as 1 | 2 | 3)}
+            className={`rounded-full px-4 py-1 ${
+              value === y ? "bg-blue-600 text-white" : "bg-gray-200 text-black"
+            }`}
+          >
+            {y}Y
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend-2/src/hooks/useLoanCalculator.ts
+++ b/frontend-2/src/hooks/useLoanCalculator.ts
@@ -1,0 +1,20 @@
+"use client";
+import { useMemo } from "react";
+
+export function useLoanCalculator(amount: number, tenureYears: 1 | 2 | 3) {
+  return useMemo(() => {
+    const rateMap = { 1: 14, 2: 15, 3: 16 } as const;
+    const rate = rateMap[tenureYears];
+    const processingFee = Math.max(amount * 0.015, 999);
+    const legalFee = 2000;
+    const sanctionedMax = Number(localStorage.getItem("maxLoanAllowed")) || 0;
+    const cashback = amount >= 0.8 * sanctionedMax ? amount * 0.0025 : 0;
+    const monthlyRate = rate / 12 / 100;
+    const tenureMonths = tenureYears * 12;
+    const emi =
+      amount * monthlyRate / (1 - Math.pow(1 + monthlyRate, -tenureMonths));
+    const netDisbursed = amount - processingFee - legalFee + cashback;
+
+    return { rate, processingFee, legalFee, cashback, emi, netDisbursed };
+  }, [amount, tenureYears]);
+}

--- a/frontend-2/src/types/Offer.ts
+++ b/frontend-2/src/types/Offer.ts
@@ -1,0 +1,4 @@
+export interface Offer {
+  sanctionedMax: number;
+  cibilScore: number;
+}


### PR DESCRIPTION
## Summary
- add components for loan amount slider, tenure buttons and breakdown card
- implement `useLoanCalculator` hook
- integrate new UI on offer page with live calculations

## Testing
- `npm test` *(fails: Missing script)*
- `npm run cypress:run` *(fails: Missing script)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685bc3554088832c9c1a96f78c8971a5