### PR TITLE
Adjust sanctioned amount logic

### DIFF
--- a/frontend-2/src/hooks/useLoanCalculator.ts
+++ b/frontend-2/src/hooks/useLoanCalculator.ts
@@ -1,18 +1,30 @@
 "use client";
 import { useMemo } from "react";
 
+const rateMap = { 1: 14, 2: 15, 3: 16 } as const;
+
+export function calcEmi(principal: number, tenureYears: 1 | 2 | 3) {
+  const rate = rateMap[tenureYears];
+  const monthlyRate = rate / 12 / 100;
+  const tenureMonths = tenureYears * 12;
+  return principal * monthlyRate / (1 - Math.pow(1 + monthlyRate, -tenureMonths));
+}
+
+export function principalFromEmi(emi: number, tenureYears: 1 | 2 | 3) {
+  const rate = rateMap[tenureYears];
+  const monthlyRate = rate / 12 / 100;
+  const tenureMonths = tenureYears * 12;
+  return emi * (1 - Math.pow(1 + monthlyRate, -tenureMonths)) / monthlyRate;
+}
+
 export function useLoanCalculator(amount: number, tenureYears: 1 | 2 | 3) {
   return useMemo(() => {
-    const rateMap = { 1: 14, 2: 15, 3: 16 } as const;
     const rate = rateMap[tenureYears];
     const processingFee = Math.max(amount * 0.015, 999);
     const legalFee = 2000;
     const sanctionedMax = Number(localStorage.getItem("maxLoanAllowed")) || 0;
     const cashback = amount >= 0.8 * sanctionedMax ? amount * 0.0025 : 0;
-    const monthlyRate = rate / 12 / 100;
-    const tenureMonths = tenureYears * 12;
-    const emi =
-      amount * monthlyRate / (1 - Math.pow(1 + monthlyRate, -tenureMonths));
+    const emi = calcEmi(amount, tenureYears);
     const netDisbursed = amount - processingFee - legalFee + cashback;
 
     return { rate, processingFee, legalFee, cashback, emi, netDisbursed };


### PR DESCRIPTION
## Summary
- compute max loan in backend based on EMI capacity and CIBIL score
- expose EMI helpers for loan calculator hook
- default to 3 year tenure and adjust max amount when tenure changes

## Testing
- `pip install flask pytest sqlalchemy flask_cors flask_sqlalchemy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bce14d7f0832c97148b7ec09153c9