### PR TITLE
Implement loan agreement generation

### DIFF
--- a/frontend-2/src/app/sanction-result/page.tsx
+++ b/frontend-2/src/app/sanction-result/page.tsx
@@ -8,6 +8,7 @@ import { useLoanCalculator } from "@/hooks/useLoanCalculator";
 import EmiDateSelector from "@/components/EmiDateSelector";
 import EmiScheduleTable from "@/components/EmiScheduleTable";
 import { useEmiSchedule } from "@/hooks/useEmiSchedule";
+import { BACKEND_URL } from "@/constants/layout";
 
 export default function SanctionResult() {
   const [score, setScore] = useState(0);
@@ -29,11 +30,23 @@ export default function SanctionResult() {
 
   const acceptOffer = async () => {
     try {
-      await fetch("/loans", {
+      const borrower = localStorage.getItem("username") || "Borrower";
+      const res = await fetch(`${BACKEND_URL}/api/agreements/generate`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ amount, tenureYears: tenure }),
+        body: JSON.stringify({
+          BorrowerName: borrower,
+          Amount: amount,
+          Tenure: tenure,
+          Rate: breakdown.rate,
+          Emi: breakdown.emi.toFixed(2),
+          StartDate: schedule[0]?.date,
+        }),
       });
+      const data = await res.json();
+      if (res.ok && data.DocumentURL) {
+        window.open(`${BACKEND_URL}/${data.DocumentURL}`, "_blank");
+      }
       alert("Accepted");
     } catch (e) {
       console.error(e);
@@ -44,7 +57,7 @@ export default function SanctionResult() {
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      className="mx-auto mt-10 max-w-md space-y-6 rounded-3xl bg-white/10 p-6 text-center backdrop-blur"
+      className="mx-auto mt-10 w-[95%] md:w-[60%] space-y-6 rounded-3xl bg-white/10 p-6 text-center backdrop-blur"
     >
       <h1 className="text-3xl font-bold">🎉 Your Offer Is Ready!</h1>
       <div className="flex justify-around">

--- a/frontend-2/src/components/EmiScheduleTable.tsx
+++ b/frontend-2/src/components/EmiScheduleTable.tsx
@@ -11,7 +11,7 @@ const format = (n: number) =>
 
 export default function EmiScheduleTable({ schedule }: Props) {
   return (
-    <motion.div layout className="max-h-64 overflow-auto rounded-3xl bg-white/20 p-4 shadow">
+    <motion.div layout className="max-h-64 overflow-auto rounded-3xl bg-white/20 p-4 shadow mt-4">
       <table className="w-full text-left text-sm">
         <thead>
           <tr>

--- a/frontend-2/src/hooks/useEmiSchedule.ts
+++ b/frontend-2/src/hooks/useEmiSchedule.ts
@@ -37,7 +37,7 @@ export function useEmiSchedule(
       balance = Math.max(0, balance - principal);
       rows.push({
         month: i + 1,
-        date: due.toISOString().split("T")[0],
+        date: due.toLocaleDateString("en-CA"),
         principal,
         interest,
         total: principal + interest,

--- a/los-flask-app/los/__init__.py
+++ b/los-flask-app/los/__init__.py
@@ -13,6 +13,7 @@ from los.api.loan_application_routes import loan_application_bp
 from los.api.credit_score_routes import credit_score_bp
 from los.api.cibil_routes import cibil_bp
 from los.api.system_notification_routes import system_notification_bp
+from los.api.agreement_routes import agreement_bp
 
 
 def create_app():
@@ -35,5 +36,6 @@ def create_app():
     app.register_blueprint(credit_score_bp)
     app.register_blueprint(cibil_bp)
     app.register_blueprint(system_notification_bp)
+    app.register_blueprint(agreement_bp)
 
     return app

--- a/los-flask-app/los/api/agreement_routes.py
+++ b/los-flask-app/los/api/agreement_routes.py
@@ -1,0 +1,58 @@
+from flask import Blueprint, request, jsonify
+from fpdf import FPDF
+from los.models import db, Document, User
+import os
+from datetime import datetime
+
+agreement_bp = Blueprint("agreement", __name__, url_prefix="/api/agreements")
+
+@agreement_bp.route("/generate", methods=["POST"])
+def generate_agreement():
+    data = request.json or {}
+    required = ["BorrowerName", "Amount", "Tenure", "Rate", "Emi", "StartDate"]
+    missing = [k for k in required if k not in data]
+    if missing:
+        return jsonify({"message": f"Missing fields: {', '.join(missing)}"}), 400
+
+    user = None
+    if "UserID" in data:
+        user = User.query.get(data["UserID"])
+
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    borrower = data.get("BorrowerName")
+    lines = [
+        "Loan Agreement",
+        "",
+        f"Borrower: {borrower}",
+        f"Amount: {data['Amount']}",
+        f"Tenure: {data['Tenure']} years",
+        f"Interest Rate: {data['Rate']}%",
+        f"EMI: {data['Emi']}",
+        f"Start Date: {data['StartDate']}",
+        "",
+        "The borrower agrees to repay the loan in equal monthly instalments",
+        "including interest as specified above. Late payments may incur ",
+        "additional charges. This agreement is governed by applicable laws.",
+    ]
+    for line in lines:
+        pdf.cell(0, 10, txt=line, ln=1)
+
+    os.makedirs("agreements", exist_ok=True)
+    uid = data.get("UserID") if user else "generic"
+    filename = f"agreement_{uid}_{int(datetime.utcnow().timestamp())}.pdf"
+    filepath = os.path.join("agreements", filename)
+    pdf.output(filepath)
+
+    if user:
+        doc = Document(
+            UserID=user.UserID,
+            DocumentType="Loan Agreement",
+            DocumentURL=filepath,
+            Status="Verified",
+        )
+        db.session.add(doc)
+        db.session.commit()
+
+    return jsonify({"message": "Agreement generated", "DocumentURL": filepath})

--- a/los-flask-app/requirements.txt
+++ b/los-flask-app/requirements.txt
@@ -24,3 +24,4 @@ typing_extensions==4.12.2
 Werkzeug==3.1.3
 WTForms==3.2.1
 pytest==8.2.0
+fpdf2==2.7.8


### PR DESCRIPTION
## Summary
- add FPDF dependency for generating PDFs
- expose new `/api/agreements/generate` endpoint
- register blueprint in Flask app
- widen sanction result layout and trigger agreement creation
- fix EMI schedule date bug and table spacing

## Testing
- `pip install -r los-flask-app/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd56d5c38832c84863f5d7ee196bd