### PR TITLE
Fix sanction results defaults

### DIFF
--- a/frontend-2/src/app/sanction-result/page.tsx
+++ b/frontend-2/src/app/sanction-result/page.tsx
@@ -17,6 +17,7 @@ export default function SanctionResult() {
   const [tenure, setTenure] = useState<1 | 2 | 3>(3);
   const [emiDay, setEmiDay] = useState(1);
   const [tenureMax, setTenureMax] = useState(0);
+  const [initialized, setInitialized] = useState(false);
 
   useEffect(() => {
     const s = Number(localStorage.getItem("cibilScore"));
@@ -33,8 +34,11 @@ export default function SanctionResult() {
   useEffect(() => {
     const max = adjustMax(sanctionedMax, tenure, breakdown.rate);
     setTenureMax(max);
-    setAmount((a) => Math.min(a, max));
-  }, [sanctionedMax, tenure, breakdown.rate]);
+    setAmount((a) =>
+      initialized ? Math.min(Math.max(a, 10000), max) : max
+    );
+    if (!initialized) setInitialized(true);
+  }, [sanctionedMax, tenure, breakdown.rate, initialized]);
 
   const adjustMax = (
     base: number,
@@ -45,7 +49,9 @@ export default function SanctionResult() {
     const factor36 = (1 - Math.pow(1 + r, -36)) / r;
     const emiCap = base / factor36;
     const factorT = (1 - Math.pow(1 + r, -(yrs * 12))) / r;
-    return Math.floor(emiCap * factorT);
+    const raw = emiCap * factorT;
+    const rounded = Math.round(raw / 1000) * 1000;
+    return Math.max(10000, rounded);
   };
 
   const router = useRouter();

--- a/frontend-2/src/components/CostBreakdownCard.tsx
+++ b/frontend-2/src/components/CostBreakdownCard.tsx
@@ -31,7 +31,7 @@ export default function CostBreakdownCard({
           </tr>
           <tr>
             <td className="py-1">Interest %</td>
-            <td className="py-1 text-right">{rate} % p.a.</td>
+            <td className="py-1 text-right">{rate.toFixed(2)} % p.a.</td>
           </tr>
           <tr>
             <td className="py-1">Processing</td>

--- a/frontend-2/src/components/EmiDateSelector.tsx
+++ b/frontend-2/src/components/EmiDateSelector.tsx
@@ -9,17 +9,21 @@ export default function EmiDateSelector({ value, onChange }: Props) {
   return (
     <div className="space-y-2">
       <p className="font-medium">Select EMI Date</p>
-      <select
-        className="w-full rounded-3xl border border-gray-300 p-2"
-        value={value}
-        onChange={(e) => onChange(Number(e.target.value))}
-      >
-        {Array.from({ length: 28 }, (_, i) => i + 1).map((d) => (
-          <option key={d} value={d}>
-            {d}
-          </option>
-        ))}
-      </select>
+      <div className="flex items-center">
+        <select
+          className="w-full rounded-3xl border border-gray-300 p-2"
+          value={value}
+          onChange={(e) => onChange(Number(e.target.value))}
+        >
+          {Array.from({ length: 28 }, (_, i) => i + 1).map((d) => (
+            <option key={d} value={d}>
+              {d}
+            </option>
+          ))}
+        </select>
+        <span className="ml-2">of every month</span>
+      </div>
     </div>
   );
 }
+

--- a/frontend-2/src/hooks/useLoanCalculator.ts
+++ b/frontend-2/src/hooks/useLoanCalculator.ts
@@ -13,6 +13,7 @@ export function useLoanCalculator(
         : Number(localStorage.getItem("cibilScore")) || 0;
     let rate = 18 - ((score - 300) / 600) * 7;
     rate = Math.min(18, Math.max(11, rate));
+    rate = Math.round(rate * 100) / 100;
     const processingFee = Math.max(amount * 0.015, 999);
     const legalFee = 2000;
     const sanctionedMax = Number(localStorage.getItem("maxLoanAllowed")) || 0;


### PR DESCRIPTION
## Summary
- tweak loan defaults and rounding logic in sanction result page
- show EMI date suffix
- format interest rate
- round interest calculation to two decimals

## Testing
- `npm run lint` *(fails: next not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685beb2a4b8c832cbe29f411b6e41eab