### PR TITLE
Set default rent for owned homes

### DIFF
--- a/frontend-2/src/app/client/user-application/helpers/handle-submit.ts
+++ b/frontend-2/src/app/client/user-application/helpers/handle-submit.ts
@@ -88,7 +88,10 @@ export const handleSubmit = async (
       District: values.district,
       Zip: values.pincode,
       AddressType: values.addressType,
-      MonthlyHomeRent: values.monthlyHomeRent,
+      MonthlyHomeRent:
+        values.addressType === "rented"
+          ? Number(values.monthlyHomeRent || 0)
+          : 0,
     };
 
     //Address Details

--- a/frontend-2/src/app/client/user-application/index.tsx
+++ b/frontend-2/src/app/client/user-application/index.tsx
@@ -34,7 +34,13 @@ const UserApplication: FunctionComponent<UserApplicationProps> = ({ data }) => {
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
-    setValues((prev) => ({ ...prev, [name]: value }));
+    setValues((prev) => {
+      const updated = { ...prev, [name]: value };
+      if (name === "addressType" && value === "owned") {
+        updated.monthlyHomeRent = "0";
+      }
+      return updated;
+    });
   };
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Summary
- set MonthlyHomeRent to 0 when address type is owned
- send numeric value to backend during address submit

## Testing
- `pytest -q`
- `npm run lint` *(fails: 'Controller' is defined but never used, 'control' is assigned a value but never used, 'motion' is defined but never used, 'Unexpected any', and a React hook missing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_685d14c4f7cc832cbfff7237a1dbb043