### PR TITLE
Record application id on form submission

### DIFF
--- a/frontend-2/src/app/client/user-application/helpers/handle-submit.ts
+++ b/frontend-2/src/app/client/user-application/helpers/handle-submit.ts
@@ -156,6 +156,31 @@ export const handleSubmit = async (
       body: JSON.stringify({ UserID: userId, Score: cibilData.score }),
     });
 
+    // Create a loan application record so we can reference the Application ID
+    try {
+      const applicationRes = await fetch(`${BACKEND_URL}/api/loan_applications/`, {
+        method: "POST",
+        mode: "cors",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          UserID: userId,
+          ProductID: 1,
+          LoanOfferID: 1,
+        }),
+      });
+      const appData = await applicationRes.json();
+      if (applicationRes.ok && appData.loan_application?.ApplicationID) {
+        window.localStorage.setItem(
+          "applicationId",
+          String(appData.loan_application.ApplicationID),
+        );
+      }
+    } catch (error) {
+      console.error("Error creating loan application:", error);
+    }
+
     router.push("/sanction-result");
   } catch (error) {
     console.error("API Request Error:", error);

--- a/frontend-2/src/app/sanction-result/page.tsx
+++ b/frontend-2/src/app/sanction-result/page.tsx
@@ -18,6 +18,7 @@ export default function SanctionResult() {
   const [emiDay, setEmiDay] = useState(1);
   const [tenureMax, setTenureMax] = useState(0);
   const [initialized, setInitialized] = useState(false);
+  const [applicationId, setApplicationId] = useState<string | null>(null);
 
   useEffect(() => {
     const cibilScore = Number(localStorage.getItem("cibilScore"));
@@ -25,6 +26,8 @@ export default function SanctionResult() {
     setScore(isNaN(cibilScore) ? 0 : cibilScore);
     const roundedLoanAmount = isNaN(loan) ? 0 : Math.round(loan / 1000) * 1000;
     setSanctionedMax(roundedLoanAmount);
+    const id = localStorage.getItem("applicationId");
+    if (id) setApplicationId(id);
   }, []);
 
   const breakdown = useLoanCalculator(amount, tenure, score);
@@ -69,6 +72,9 @@ export default function SanctionResult() {
       className="mx-auto mt-10 w-[95%] space-y-6 rounded-3xl bg-white/10 p-6 text-center backdrop-blur md:w-[60%]"
     >
       <h1 className="text-3xl font-bold">🎉 Your Offer Is Ready!</h1>
+      {applicationId && (
+        <p className="text-lg font-semibold">Application ID: {applicationId}</p>
+      )}
       <div className="flex justify-around">
         <motion.div className="w-1/2 p-4">
           <div className="rounded-3xl bg-white/20 p-4 shadow">


### PR DESCRIPTION
## Summary
- create a loan application after user info is submitted
- store returned application ID in `localStorage`
- read the ID on the sanction result page and display it

## Testing
- `pip install -r los-flask-app/requirements.txt`
- `PYTHONPATH=los-flask-app pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877809d75a8832c90fa68881c964ef0