### PR TITLE
Move PDF wording to template and drop borrower name

### DIFF
--- a/frontend-2/src/app/agreement/page.tsx
+++ b/frontend-2/src/app/agreement/page.tsx
@@ -6,12 +6,12 @@ export default function AgreementPage() {
   const params = useSearchParams();
   const router = useRouter();
 
-  const borrower = params.get("BorrowerName") ?? "Borrower";
   const amount = params.get("Amount") ?? "";
   const tenure = params.get("Tenure") ?? "";
   const rate = params.get("Rate") ?? "";
   const emi = params.get("Emi") ?? "";
   const start = params.get("StartDate") ?? "";
+  const appId = params.get("ApplicationID") ?? "";
 
   const accept = async () => {
     try {
@@ -19,13 +19,12 @@ export default function AgreementPage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          BorrowerName: borrower,
+          ApplicationID: Number(appId || 0),
           Amount: Number(amount),
           Tenure: Number(tenure),
           Rate: Number(rate),
           Emi: Number(emi),
           StartDate: start,
-          ApplicationID: 1,
         }),
       });
       const data = await res.json();
@@ -39,24 +38,30 @@ export default function AgreementPage() {
   };
 
   return (
-    <div className="mx-auto mt-10 w-[95%] md:w-[60%] space-y-4 rounded-3xl bg-white/10 p-6 text-center backdrop-blur">
+    <div className="mx-auto mt-10 w-[95%] space-y-4 rounded-3xl bg-white/10 p-6 text-center backdrop-blur md:w-[60%]">
       <h1 className="text-3xl font-bold">Loan Agreement</h1>
-      <p>Borrower: {borrower}</p>
       <p>Amount: {amount}</p>
       <p>Tenure: {tenure} years</p>
       <p>Interest Rate: {rate}%</p>
       <p>EMI: {emi}</p>
       <p>Start Date: {start}</p>
+      <p>Application ID: {appId}</p>
       <p>
         The borrower agrees to repay the loan in equal monthly instalments
         including interest as specified above. Late payments may incur
         additional charges. This agreement is governed by applicable laws.
       </p>
       <div className="flex justify-center gap-4">
-        <button onClick={accept} className="rounded-full bg-blue-600 px-4 py-2 text-white">
+        <button
+          onClick={accept}
+          className="rounded-full bg-blue-600 px-4 py-2 text-white"
+        >
           Accept & Download
         </button>
-        <button onClick={() => router.back()} className="rounded-full bg-orange-500 px-4 py-2 text-white">
+        <button
+          onClick={() => router.back()}
+          className="rounded-full bg-orange-500 px-4 py-2 text-white"
+        >
           Back
         </button>
       </div>

--- a/frontend-2/src/app/sanction-result/page.tsx
+++ b/frontend-2/src/app/sanction-result/page.tsx
@@ -53,9 +53,8 @@ export default function SanctionResult() {
   const router = useRouter();
 
   const acceptOffer = () => {
-    const borrower = localStorage.getItem("username") ?? "Borrower";
     const params = new URLSearchParams({
-      BorrowerName: borrower,
+      ApplicationID: applicationId || "",
       Amount: String(amount),
       Tenure: String(tenure),
       Rate: String(breakdown.rate),

--- a/los-flask-app/los/api/agreement_routes.py
+++ b/los-flask-app/los/api/agreement_routes.py
@@ -3,9 +3,6 @@ from fpdf import FPDF
 from datetime import datetime
 import os
 from flask_cors import CORS
-from los.models import db, Loan
-
-
 from los.models import db, Document, User, LoanApplication, Loan
 
 agreement_bp = Blueprint(
@@ -16,11 +13,11 @@ agreement_bp = Blueprint(
 )
 CORS(agreement_bp)
 
+
 @agreement_bp.route("/view", methods=["GET"])
 def view_agreement():
     args = request.args
     required = [
-        "BorrowerName",
         "Amount",
         "Tenure",
         "Rate",
@@ -37,7 +34,6 @@ def view_agreement():
 def accept_agreement():
     data = request.json or {}
     required = [
-        "BorrowerName",
         "Amount",
         "Tenure",
         "Rate",
@@ -62,16 +58,14 @@ def accept_agreement():
     start_date = datetime.strptime(data["StartDate"], "%Y-%m-%d").date()
 
     pdf = FPDF()
-    borrower = data.get("BorrowerName")
 
-    # Page 1 - summary with borrower name
+    # Page 1 - summary
     pdf.add_page()
     pdf.set_font("Arial", "B", 14)
     pdf.cell(0, 10, txt="Loan Agreement", ln=1, align="C")
     pdf.ln(5)
     pdf.set_font("Arial", size=12)
     summary_lines = [
-        f"Borrower: {borrower}",
         f"Application ID: {data['ApplicationID']}",
         f"Amount: {data['Amount']}",
         f"Tenure: {data['Tenure']} years",
@@ -128,22 +122,23 @@ def accept_agreement():
     return jsonify({"message": "Agreement generated", "DocumentURL": filepath})
 
 
-
 @agreement_bp.route("/", methods=["GET"])
 def get_agreements():
     agreements = Loan.query.all()
-    return jsonify([
-        {
-            "LoanID": p.LoanID,
-            "ApplicationID": p.ApplicationID,
-            "PrincipalAmount": p.PrincipalAmount,
-            "InterestRate": p.InterestRate,
-            "Tenure": str(p.Tenure),
-            "StartDate": p.StartDate,
-            "Status": p.Status,
-            "Emi": str(p.Emi),
-            "CreatedAt": p.CreatedAt,
-            "UpdatedAt": p.UpdatedAt
-        }
-        for p in agreements
-    ])
+    return jsonify(
+        [
+            {
+                "LoanID": p.LoanID,
+                "ApplicationID": p.ApplicationID,
+                "PrincipalAmount": p.PrincipalAmount,
+                "InterestRate": p.InterestRate,
+                "Tenure": str(p.Tenure),
+                "StartDate": p.StartDate,
+                "Status": p.Status,
+                "Emi": str(p.Emi),
+                "CreatedAt": p.CreatedAt,
+                "UpdatedAt": p.UpdatedAt,
+            }
+            for p in agreements
+        ]
+    )

--- a/los-flask-app/los/templates/agreement.html
+++ b/los-flask-app/los/templates/agreement.html
@@ -6,12 +6,20 @@
 </head>
 <body>
     <h1>Loan Agreement</h1>
-    <p>Borrower: {{ BorrowerName }}</p>
+    <p>Application ID: {{ ApplicationID }}</p>
     <p>Amount: {{ Amount }}</p>
     <p>Tenure: {{ Tenure }} years</p>
     <p>Interest Rate: {{ Rate }}%</p>
     <p>EMI: {{ Emi }}</p>
     <p>Start Date: {{ StartDate }}</p>
-    <p>The borrower agrees to repay the loan in equal monthly instalments including interest as specified above. Late payments may incur additional charges. This agreement is governed by applicable laws.</p>
+    <h2>Terms and Conditions</h2>
+    <p>The borrower agrees to repay the loan in equal monthly instalments
+    including interest as specified above. Late payments may incur
+    additional charges. This agreement is governed by applicable laws and
+    complies with relevant Reserve Bank of India guidelines for consumer
+    lending. All disputes are subject to jurisdiction of the lender's
+    registered office. By signing, the borrower accepts the terms outlined
+    herein and acknowledges the repayment schedule.</p>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- remove borrower parameter from agreement view/accept routes
- shift agreement text into `agreement.html` template
- update FPDF generation and HTML template accordingly
- pass `ApplicationID` when generating agreement and drop borrower field in UI

## Testing
- `black los-flask-app/los/api/agreement_routes.py`
- `PYTHONPATH=los-flask-app pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877895431dc832cbadd7e3dc7733f20